### PR TITLE
Create some test infrastructure to compare results of ES5 and ES2015

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -199,7 +199,7 @@
     "no-octal-escape": 2,
     "no-this-before-super": 2,
     "no-alert": 0,
-    "no-unused-expressions": 2,
+    "no-unused-expressions": 0,
     "no-class-assign": 2,
     "spaced-comment": [
       2,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mocha": "^2.3.4"
   },
   "devDependencies": {
-    "babel-core": "^5.8.21"
+    "babel-core": "^5.8.21",
+    "coffee-script": "^1.10.0"
   }
 }

--- a/test/for-in-loops.js
+++ b/test/for-in-loops.js
@@ -1,0 +1,13 @@
+const compareResult = require("./util/compare-result");
+const forInLoopsTransform = require("../transforms/for-in-loops");
+
+describe("for-in-loops", () => {
+  compareResult("Iterating through a list", forInLoopsTransform, `
+    ((input, output) ->
+      for item in input
+        output.push item
+    )([1, '2', '3', 'string'], [])
+  `);
+});
+
+

--- a/test/util/compare-result.js
+++ b/test/util/compare-result.js
@@ -1,0 +1,18 @@
+const { expect } = require("chai");
+const jscodeshift = require("jscodeshift");
+const { compile } = require("coffee-script");
+
+module.exports = (testName, transform, source) => {
+  it(testName, () => {
+    const ES5Source = compile(source, { bare: true });
+    const transformedSource = transform({ ES5Source }, { jscodeshift });
+
+    // We expect the transform to change the output
+    expect(transformedSource).not.to.be.null;
+
+    /* eslint-disable no-eval */
+    expect(eval(source)).to.deep.eq(eval(transformedSource));
+    /* eslint-enable no-eval */
+  });
+};
+


### PR DESCRIPTION
The test is actually failing:

```
  1) for-in-loops Iterating through a list:
     TypeError: Received an unexpected value [object Undefined]
    at fromAST (node_modules/jscodeshift/dist/core.js:68:9)
    at core (node_modules/jscodeshift/dist/core.js:44:60)
    at module.exports (transforms/for-in-loops.js:28:14)
    at Context.<anonymous> (test/util/compare-result.js:16:29)
```

But this is the general idea of how I would like to add some sanity tests for the transforms.
